### PR TITLE
fix: use different sharedname env variable value

### DIFF
--- a/docs/assignment-7.md
+++ b/docs/assignment-7.md
@@ -121,7 +121,7 @@ In order to add environment variables, take the following steps:
   env_file:
   - ./envfile.env
   env:
-  - SharedName=MailAPipecifickey
+  - SharedName=MailAPISpecificKey
   - Mailapi_key=mailapi
   ```
 
@@ -131,7 +131,7 @@ In order to add environment variables, take the following steps:
   ```yaml
   env:
   - name: SharedName
-    value: MailAPipecifickey
+    value: WeatherAPISpecificKey
   ```
 
 ### Step 6. Find the new secret values


### PR DESCRIPTION
This fix ensures the following statement in assignment 7's instructions is correct:

> When getting the secret value for "SharedName" from "MailAPI" or "WeatherAPI", different values are shown.